### PR TITLE
Change default constructor from nil to a table

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Rochet
+Copyright (c) 2022 Rochet2
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -128,20 +128,20 @@ Constructors do not throw. Watch out for quirks with initializer list constructo
 LuaVal implicit_test = -123;
 LuaVal copy_test(implicit_test);
 LuaVal copy_test2 = implicit_test;
-LuaVal n; // nil
+LuaVal n = LuaVal::nil; // nil
+LuaVal n2(TNIL); // nil
 LuaVal b(true);
 LuaVal s("a string");
 LuaVal d(123.456);
 LuaVal f(123.456f);
 LuaVal i(-678);
 LuaVal u(0xFFFFFFF);
-LuaVal t1(TTABLE); // create a value through typetag creates empty or zero initialized value
-LuaVal t2 = LuaVal::table(); // another way to create tables
-LuaVal t3 = { 1, 2, { 1,2,3 } }; // initializer list is supported for making sequences (tables)
-LuaVal t4 = LuaVal::LuaTable{ { "key", "value" }, { 2, "value2" } }; // Table can be created with map table initializer list constructor also
-
-// watch out - depending on C++ version serializes to {2:{},3:{3},4:4}
-LuaVal quirks = { {}, {{}}, { 3 }, { LuaVal(4) } };
+LuaVal t; // defaults to table
+LuaVal t2 = LuaVal::table();
+LuaVal t3 = { 1, 2, { 1,2,3 } };
+LuaVal t4 = {};
+LuaVal t5(TTABLE);
+LuaVal t6 = LuaVal::LuaTable{ { "key", "value" }, { 2, "value2" } }; // Table can be created with map table initializer list constructor also
 
 // You can mix and match a lot of different types and containers for creating tables.
 // For example vectors, lists, maps, arrays are supported for creating LuaVal.
@@ -222,7 +222,7 @@ The function `set` returns the accessed table itself, so you can chain it to set
 When a value is attempted to be set as nil, it will be erased from the table instead.
 These functions do not throw unless you use them on non table objects or with nil keys. `luaval.setignore(key, value)` works like `luaval.set(key, value)`, except it will not do anything if a value already exists in the table for that key.
 
-The get method above will provide only const reference access to the table elements. For non const access to elements you must use the `[]` operator like so `luaval[key]`. If the accessed key does not exist in the accessed table then a nil value is created to the table for that key. This means that accessing nonexisting elements will create clutter to the table. Setting a value to nil will not erase it from the table.
+The get method above will provide only const reference access to the table elements. For non const access to elements you must use the `[]` operator like so `luaval[key]`. If the accessed key does not exist in the accessed table then a table value is created to the table for that key. This means that accessing nonexisting elements will create clutter to the table. Setting a value to nil using brackets will store a nil value to the table instead of removing the key from the table.
 This operator does not throw unless you use it on non table objects or with nil keys.
 
 `luaval.has(key)` can be used to check if a value can be found in a table.

--- a/main.cpp
+++ b/main.cpp
@@ -28,21 +28,25 @@ int main()
         LuaVal implicit_test = -123;
         LuaVal copy_test(implicit_test);
         LuaVal copy_test2 = implicit_test;
-        LuaVal n; // nil
+        LuaVal n = LuaVal::nil; // nil
+        LuaVal n2(TNIL); // nil
         LuaVal b(true);
         LuaVal s("somestring");
         LuaVal d(123.456);
         LuaVal f(123.456f);
         LuaVal i(-678);
         LuaVal u(0xFFFFFFFF);
-        LuaVal t(TTABLE);
+        LuaVal t; // defaults to table
         LuaVal t2 = LuaVal::table();
         LuaVal t3 = { 1, 2, 3 };
+        LuaVal t4 = {}; // curly braces are table
+        LuaVal t5(TTABLE);
 
         assert(implicit_test.isnumber());
         assert(copy_test.isnumber());
         assert(copy_test2.isnumber());
         assert(n.isnil());
+        assert(n2.isnil());
         assert(b.isbool());
         assert(s.isstring());
         assert(d.isnumber());
@@ -52,6 +56,8 @@ int main()
         assert(t.istable());
         assert(t2.istable());
         assert(t3.istable());
+        assert(t4.istable());
+        assert(t5.istable());
 
         std::cout << implicit_test.tostring() << std::endl;
         std::cout << copy_test.tostring() << std::endl;
@@ -150,28 +156,33 @@ int main()
 
     {
         std::cout << "Table initializer list coolness" << std::endl;
-        std::cout << "Watch out for quirks though!" << std::endl;
-        std::cout << "What stuff evaluates to depends on your compiler and C++ version!" << std::endl;
-        std::cout << "{} evaluates to nil" << std::endl;
-        std::cout << "{{}} evaluates to a nil inside a table" << std::endl;
+        std::cout << "{} evaluates to table" << std::endl;
+        std::cout << "{{}} evaluates to a table inside a table" << std::endl;
         std::cout << "{5} evaluates to 5 being inside a table" << std::endl;
-        std::cout << "{LuaVal(5)} evaluates to just 5 instead of being a 5 inside a table" << std::endl;
+        std::cout << "{LuaVal(5)} evaluates to 5 inside a table" << std::endl;
 
-        // Watch out for quirks though as seen in the serialized output: http://stackoverflow.com/questions/26947704/implicit-conversion-failure-from-initializer-list
         LuaVal nested = { {}, {{}}, { 3 }, { LuaVal(4) } };
-        std::cout << nested.dumps() << std::endl;
+        std::cout << nested.dumps() << std::endl; // Outputs {{},{{}},{3},{4}}
         std::cout << std::endl;
     }
 
     {
         std::cout << "test accessing table with [] operator" << std::endl;
         std::cout << "Note that table keys cannot be accessed!" << std::endl;
-        std::cout << "Notice the excessive amount of nils left behind!" << std::endl;
+        std::cout << "Notice the excessive amount of tables left behind!" << std::endl;
+        LuaVal nested = {};
+        nested[1];
+        nested[2];
+        nested[3];
+        nested[4][5][6]; // handy for quick creation of nested indexes
+        std::cout << nested.dumps() << std::endl; // Outputs {{},{},{},{5:{6:{}}}}
+        std::cout << std::endl;
 
+        // To avoid unnecessary tables, use set and get (similar to at in c++ for map)
         LuaVal table(TTABLE);
         table.set(1, "test");
         std::cout << table.dumps() << std::endl;
-        table.set(1, LuaVal()); // removing value through setting it to nil
+        table.set(1, LuaVal::nil); // removing value through setting it to nil
         std::cout << table.dumps() << std::endl;
         table.set(table, "table as key?");
         std::cout << table.dumps() << std::endl;
@@ -210,7 +221,7 @@ int main()
 
     {
         LuaVal val = 5;
-        LuaVal val2;
+        LuaVal val2 = LuaVal::nil;
         if (val)
             std::cout << "bool() works" << std::endl;
         if (!val2)

--- a/smallfolk.cpp
+++ b/smallfolk.cpp
@@ -37,7 +37,7 @@ namespace Serializer
     LuaVal expect_object(std::string const & string, size_t& i, TABLES& tables);
 }
 
-LuaVal const LuaVal::nil;
+LuaVal const LuaVal::nil(TNIL);
 
 std::string LuaVal::tostring() const
 {
@@ -278,7 +278,7 @@ LuaVal LuaVal::loads(std::string const & string, std::string * errmsg)
         if (errmsg)
             *errmsg += e.what();
     }
-    return LuaVal();
+    return LuaVal::nil;
 }
 
 bool LuaVal::operator==(LuaVal const& rhs) const
@@ -561,7 +561,7 @@ LuaVal Serializer::expect_object(std::string const & string, size_t & i, Seriali
     case 'f':
         return false;
     case 'n':
-        return LuaVal();
+        return LuaVal::nil;
     case 'Q':
         return -(0 / _zero);
     case 'N':
@@ -669,7 +669,7 @@ LuaVal Serializer::expect_object(std::string const & string, size_t & i, Seriali
         break;
     }
     }
-    return LuaVal();
+    return LuaVal::nil;
 }
 
 smallfolk_exception::smallfolk_exception(const char * format, ...) : std::logic_error("Smallfolk exception")

--- a/smallfolk.h
+++ b/smallfolk.h
@@ -53,7 +53,7 @@ class LuaVal
 {
 public:
 
-    // static nil value, same as LuaVal();
+    // static nil value, same as LuaVal(TNIL);
     // You can use it as for example as default const reference
     static LuaVal const nil;
 
@@ -70,7 +70,7 @@ public:
     typedef std::unique_ptr<LuaTable> TblPtr; // circular reference memleak if insert self to self
 
     LuaVal(const LuaTypeTag tag) : tag(tag), tbl_ptr(tag == TTABLE ? new LuaTable() : nullptr), d(0), b(false) {}
-    LuaVal() : tag(TNIL), tbl_ptr(nullptr), d(0), b(false) {}
+    LuaVal() : tag(TTABLE), tbl_ptr(new LuaTable()), d(0), b(false) {}
     LuaVal(const int d) : tag(TNUMBER), tbl_ptr(nullptr), d(d), b(false) {}
     LuaVal(const unsigned int d) : tag(TNUMBER), tbl_ptr(nullptr), d(d), b(false) {}
     LuaVal(const double d) : tag(TNUMBER), tbl_ptr(nullptr), d(d), b(false) {}


### PR DESCRIPTION
This should make it less confusing when one uses curly braces to make a table when mimicing lua. It also removes some of the quirks.